### PR TITLE
Run automated tests using Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,3 @@
+language: python
+install: pip install flake8
+script: flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics


### PR DESCRIPTION
Log into https://travis-ci.com/killgcd with GitHub credentials to turn on this free service.